### PR TITLE
bugfix: fix url_for() call for login page

### DIFF
--- a/factgenie/main.py
+++ b/factgenie/main.py
@@ -86,10 +86,10 @@ def login_required(f):
         if app.config["login"]["active"]:
             auth = request.cookies.get("auth")
             if not auth:
-                return redirect(app.config["host_prefix"] + url_for("login"))
+                return redirect(url_for("login"))
             username, password = auth.split(":")
             if not utils.check_login(app, username, password):
-                return redirect(app.config["host_prefix"] + url_for("login"))
+                return redirect(url_for("login"))
 
         return f(*args, **kwargs)
 


### PR DESCRIPTION
`url_for()` will automatically get the `host_prefix`, so we don't need to combine the strings manually

Indeed, adding `app.config["host_prefix"]` to the front of the string returned by `url_for("login")` will result in redirection to `host_prefix/host_prefix/login`