### PR TITLE
Enable collecting reasons from human annotators

### DIFF
--- a/factgenie/crowdsourcing.py
+++ b/factgenie/crowdsourcing.py
@@ -270,6 +270,7 @@ def parse_crowdsourcing_config(config):
         "idle_time": int(idle_time),
         "annotation_granularity": config.get("annotationGranularity"),
         "annotation_overlap_allowed": config.get("annotationOverlapAllowed", False),
+        "annotate_reason": config.get("annotateReason", False),
         "service": config.get("service"),
         "sort_order": config.get("sortOrder"),
         "annotation_span_categories": config.get("annotationSpanCategories"),

--- a/factgenie/static/js/annotate.js
+++ b/factgenie/static/js/annotate.js
@@ -242,7 +242,8 @@ function loadAnnotations() {
         .then(() => {
             // take from metadata if defined, else false
             const annotationOverlapAllowed = metadata.config.annotation_overlap_allowed || false;
-            spanAnnotator.init(metadata.config.annotation_granularity, annotationOverlapAllowed, annotation_span_categories);
+            const annotateReason = metadata.config.annotate_reason || false;
+            spanAnnotator.init(metadata.config.annotation_granularity, annotationOverlapAllowed, annotation_span_categories, annotateReason);
 
             for (const [annotation_idx, data] of Object.entries(examples_cached)) {
                 const p = $('<p>', { id: `out-text-${annotation_idx}-par`, class: 'annotatable-paragraph' }).html(data.generated_outputs.output);

--- a/factgenie/static/js/browse.js
+++ b/factgenie/static/js/browse.js
@@ -317,7 +317,9 @@ function getAnnotatedOutput(output, annId, annotations) {
 
         // always enable showing overlapping annotations
         const overlapAllowed = true;
-        spanAnnotator.init(annotations.annotation_granularity, overlapAllowed, annotation_span_categories);
+        // don't collect reasons when just browsing existing annotations
+        const annotateReason = false;
+        spanAnnotator.init(annotations.annotation_granularity, overlapAllowed, annotation_span_categories, annotateReason);
 
         const parId = `out-text-${annId}-par`;
 

--- a/factgenie/static/js/campaigns.js
+++ b/factgenie/static/js/campaigns.js
@@ -214,6 +214,7 @@ function gatherConfig() {
         config.idleTime = $("#idleTime").val();
         config.annotationGranularity = $("#annotationGranularity").val();
         config.annotationOverlapAllowed = $("#annotationOverlapAllowed").is(":checked");
+        config.annotateReason = $("#annotateReason").is(":checked");
         config.service = $("#service").val();
         config.sortOrder = $("#sortOrder").val();
         config.annotationSpanCategories = getAnnotationSpanCategories();
@@ -537,6 +538,8 @@ function updateCrowdsourcingConfig() {
         $("#examplesPerBatch").val("");
         $("#annotatorsPerExample").val("");
         $("#idleTime").val("");
+        $("#annotationOverlapAllowed").prop("checked", false);
+        $("#annotateReason").prop("checked", false);
         $("#annotation-span-categories").empty();
         $("#flags").empty();
         $("#options").empty();
@@ -553,6 +556,7 @@ function updateCrowdsourcingConfig() {
     const idleTime = cfg.idle_time;
     const annotationGranularity = cfg.annotation_granularity;
     const annotationOverlapAllowed = cfg.annotation_overlap_allowed;
+    const annotateReason = cfg.annotate_reason;
     const service = cfg.service;
     const sortOrder = cfg.sort_order;
     const annotationSpanCategories = cfg.annotation_span_categories;
@@ -569,6 +573,7 @@ function updateCrowdsourcingConfig() {
     $("#idleTime").val(idleTime);
     $("#annotationGranularity").val(annotationGranularity);
     $("#annotationOverlapAllowed").prop("checked", annotationOverlapAllowed);
+    $("#annotateReason").prop("checked", annotateReason);
     $("#service").val(service);
     $("#sortOrder").val(sortOrder);
     $("#annotation-span-categories").empty();

--- a/factgenie/templates/pages/crowdsourcing_new.html
+++ b/factgenie/templates/pages/crowdsourcing_new.html
@@ -159,6 +159,16 @@
                 </div>
               </div>
               <div class="form-group mt-4">
+                <label for="annotateReason">Collect annotation reasons</label>
+                <div class="mb-2">
+                  <small class="form-text text-muted">Whether to ask annotators for a reason after each annotation
+                  </small>
+                </div>
+                <div class="form-check form-switch">
+                  <input type="checkbox" class="form-check-input" id="annotateReason" name="annotateReason">
+                </div>
+              </div>
+              <div class="form-group mt-4">
                 <!-- select for sort order -->
                 <label for="sortOrder">Output ordering</label>
                 <div class="mb-2">


### PR DESCRIPTION
This PR enables to collect reasons also in crowdsourcing campaigns, the same way we do in LLM campaigns:

<img width="431" height="111" alt="screen-2025-09-12-18-17-12" src="https://github.com/user-attachments/assets/32ce2625-eed1-4748-ab9f-7019da184434" />

If enabled, a dialog will appear after each highlight:

<img width="500" height="297" alt="screen-2025-09-12-18-17-42" src="https://github.com/user-attachments/assets/7b65dc99-570c-4da0-a58c-e78e664a313f" />

The collected reasons have the same role as the reasons from LLMs.

Resolves #256 