### PR TITLE
Persist browse split size across examples

### DIFF
--- a/factgenie/static/js/browse.js
+++ b/factgenie/static/js/browse.js
@@ -1,8 +1,23 @@
 var current_example_idx = 0;
 var selected_campaigns = [];
 var collapsed_boxes = [];
+const DEFAULT_SPLIT_SIZES = [66, 33];
+const SPLIT_STORAGE_KEY = "factgenie:splitSizes";
+
+function loadSplitSizes() {
+    try {
+        return JSON.parse(localStorage.getItem(SPLIT_STORAGE_KEY)) || DEFAULT_SPLIT_SIZES;
+    } catch {
+        return DEFAULT_SPLIT_SIZES;
+    }
+}
+
+function saveSplitSizes() {
+    localStorage.setItem(SPLIT_STORAGE_KEY, JSON.stringify(splitInstance.getSizes()));
+}
+
 var splitInstance = Split(['#centerpanel', '#rightpanel'], {
-    sizes: [66, 33],
+    sizes: loadSplitSizes(),
     gutterSize: 1,
 });
 
@@ -247,6 +262,7 @@ function highlightSetup() {
 }
 
 function fetchExample(dataset, split, example_idx) {
+    saveSplitSizes();
     // change the URL so that it shows the permalink
     const newUrl = `${url_prefix}/browse?dataset=${dataset}&split=${split}&example_idx=${example_idx}`;
 
@@ -278,7 +294,7 @@ function fetchExample(dataset, split, example_idx) {
             $("#examplearea").html(data.html);
             $("#centerpanel").show();
             // enable Split.js
-            splitInstance.setSizes([66, 33]);
+            splitInstance.setSizes(loadSplitSizes());
             // reset the right panel width
         }
 


### PR DESCRIPTION
This PR implements the vertical split persistence requested in #266.

Save vertical Split.js sizes in browse mode before fetching the next example and restore the split raio for the next example

Closes #266